### PR TITLE
add option for specifying lib-location

### DIFF
--- a/src/rwrapr/library.py
+++ b/src/rwrapr/library.py
@@ -3,7 +3,9 @@ import rpy2.robjects.packages as rpkg
 from .renv import Renv
 
 
-def library(env_name: str, interactive: bool = True) -> Renv:
+def library(
+    env_name: str, interactive: bool = True, lib_loc: str | None = None
+) -> Renv:
     """
     Load an R environment (package) into the current Python session.
 
@@ -15,6 +17,8 @@ def library(env_name: str, interactive: bool = True) -> Renv:
         env_name (str): The name of the R package to load.
         interactive (bool): If `True`, interactively prompts the user
             to install missing R packages. Defaults to `True`.
+        lib_loc (str | None): The location of the R package. Defaults to None
+            (Can be supplied if you are not using the default directory, e.g., if you are using renv).
 
     Returns:
         Renv: The loaded R environment.
@@ -24,14 +28,16 @@ def library(env_name: str, interactive: bool = True) -> Renv:
             `interactive` is set to `True`.
     """
     try:
-        return Renv(env_name, interactive=interactive)
+        return Renv(env_name, interactive=interactive, lib_loc=lib_loc)
     except rpkg.PackageNotInstalledError:
         if interactive:
             raise
         return Renv(None)
 
 
-def importr(env_name: str, interactive: bool = True) -> Renv:
+def importr(
+    env_name: str, interactive: bool = True, lib_loc: str | None = None
+) -> Renv:
     """
     Load an R environment (package) into the current Python session.
 
@@ -42,8 +48,10 @@ def importr(env_name: str, interactive: bool = True) -> Renv:
         env_name (str): The name of the R package to load.
         interactive (bool): If `True`, interactively prompts the user
             to install missing R packages. Defaults to `True`.
+        lib_loc (str | None): The location of the R package. Defaults to None
+            (Can be supplied if you are not using the default directory, e.g., if you are using renv).
 
     Returns:
         Renv: The loaded R environment.
     """
-    return library(env_name, interactive=interactive)
+    return library(env_name, interactive=interactive, lib_loc=lib_loc)

--- a/src/rwrapr/load_namespace.py
+++ b/src/rwrapr/load_namespace.py
@@ -19,6 +19,7 @@ def load_base_envs() -> (
 
 def try_load_namespace(
     namespace: str,
+    lib_loc: str | None = None,
     verbose: bool = False,
     hide_r_ouptut: bool = True,
     interactive: bool = True,
@@ -28,7 +29,7 @@ def try_load_namespace(
         capture.capture_r_output()
     try:
         warnings.filterwarnings("ignore")
-        module: rpkg.Package = rpkg.importr(namespace)
+        module: rpkg.Package = rpkg.importr(namespace, lib_loc=lib_loc)
     except rpkg.PackageNotInstalledError:
         if not interactive:
             raise

--- a/src/rwrapr/renv.py
+++ b/src/rwrapr/renv.py
@@ -36,13 +36,17 @@ class Renv:
         nInf (Any): Equivalent to R's `-Inf`.
     """
 
-    def __init__(self, env_name: str | None, interactive: bool = True) -> None:
+    def __init__(
+        self, env_name: str | None, interactive: bool = True, lib_loc: str | None = None
+    ) -> None:
         """
         Initializes the R environment by loading the specified R package and its associated functions and datasets.
 
         Args:
             env_name (str | None): The name of the R package to load. If `None` or an empty string, the environment is not initialized.
             interactive (bool): If True, prompts the user to install missing R packages. Defaults to True.
+            lib_loc (str | None): The location of the R package. Defaults to None
+                (Can be supplied if you are not using the default directory, e.g., if you are using renv).
         """
         if (env_name is None) or (env_name == ""):
             self.__base_lib: rpkg.Package | None = None
@@ -52,7 +56,9 @@ class Renv:
 
         pinfo("Loading packages...", verbose=True)
         self.__set_base_lib(
-            try_load_namespace(env_name, verbose=True, interactive=interactive)
+            try_load_namespace(
+                env_name, verbose=True, interactive=interactive, lib_loc=lib_loc
+            )
         )
 
         funcs, datasets = get_assets(env_name, module=self.__base_lib)


### PR DESCRIPTION
When using `renv` you will often get some (superfluous) warnings that `libraries ... contain no packages`. E.g., 

```python
rw.library("SmallCountRounding")

#> Info | Loading packages...
#> 
#> R[write to console]: In addition: 
#> R[write to console]: Warning message:
#> 
#> R[write to console]: In (function (package, help, pos = 2, lib.loc = NULL, character.only = FALSE,  :
#> R[write to console]: 
#> R[write to console]:  libraries ‘/usr/lib/R/lib’, ‘/usr/local/lib/R/site-library’ contain no packages
#>
#> Info | Done!
```

To address this i added the option for specifying which `lib_loc` you want to use. This should remove the error. The modified example:

```python
from fagfunksjoner import ProjectRoot

with ProjectRoot():
    rw.library("SmallCountRounding", lib_loc="renv/library/R-4.2/x86_64-pc-linux-gnu/")

#> Info | Loading packages...
#> Info | Done!
```

