### PR TITLE
add option for forceful conversion of s4-objects to python

### DIFF
--- a/src/rwrapr/convert_r2py.py
+++ b/src/rwrapr/convert_r2py.py
@@ -21,7 +21,7 @@ from .rview import convert_s4
 
 
 # TODO: Consider changing return type hint to union of possible types
-def convert_r2py(x: Any, ignore_s3: bool = False) -> Any:
+def convert_r2py(x: Any, ignore_s3_s4: bool = False) -> Any:
     # Need to import these here to avoid circular imports
     from .rarray import filter_numpy
     from .rarray import get_rarray
@@ -43,8 +43,8 @@ def convert_r2py(x: Any, ignore_s3: bool = False) -> Any:
         case vc.Vector() | vc.Matrix() | vc.Array() if not is_rlist(x):
             return get_rarray(x)  # return RArray, or int|str|bool|float if len == 1
         case ro.methods.RS4():
-            return convert_s4(x)
-        case _ if has_unsupported_rclass(x) and not ignore_s3:
+            return convert_s4(x, ignore_s4=ignore_s3_s4)
+        case _ if has_unsupported_rclass(x) and not ignore_s3_s4:
             return RView(x)
         case list():
             return convert_r2pylist(x)

--- a/tests/test_modsem.py
+++ b/tests/test_modsem.py
@@ -17,6 +17,29 @@ def test_to_r_and_back_to_py_s3():
     est = md.modsem(m1, data=md.oneInt, method="qml")
     out1 = md.summary(est).__str__()
 
-    est2 = est.to_py(ignore_s3=True)
+    est2 = est.to_py(ignore_s3_s4=True)
     out2 = md.summary(est2).__str__()
     assert out1 == out2
+
+
+def test_s4_to_py():
+    lav = wr.library("lavaan", interactive=False)
+    md = wr.library("modsem", interactive=False)
+
+    m1 = """
+      # Outer Model
+      X =~ x1 + x2 +x3
+      Y =~ y1 + y2 + y3
+      Z =~ z1 + z2 + z3
+
+      # Inner model
+      Y ~ X + Z
+    """
+
+    est = lav.sem(m1, data=md.oneInt)
+
+    est2 = est.to_py(ignore_s3_s4=True)
+
+    assert isinstance(est, wr.RView)
+    assert isinstance(est2, wr.RDict)
+    assert isinstance(est2["Fit"], wr.RView)  # do not convert recursively

--- a/tests/test_rview.py
+++ b/tests/test_rview.py
@@ -46,4 +46,4 @@ def test_ignore_s3_warning(setup_wr):
     est = md.modsem(m1, data=md.oneInt, method="qml")
 
     with pytest.warns(UserWarning):
-        est.to_py(ignore_s3=False)
+        est.to_py(ignore_s3_s4=False)


### PR DESCRIPTION
Previously `RWrapr` was only able to convert custom `S3` classes from `R` to `Python` object. Now it also handles `S4` classes. The `ignore_s3` argument in `Rview.to_py()` was renamed to `ignore_s3_s4` to reflect the new behaviour.